### PR TITLE
Update comment clarifying authentication status

### DIFF
--- a/FutOrganizerWeb/Controllers/BaseController.cs
+++ b/FutOrganizerWeb/Controllers/BaseController.cs
@@ -24,7 +24,9 @@ namespace FutOrganizerWeb.Controllers
                 return RedirectToAction("Login", "Login");
             }
 
-            return null; // significa que está autenticado
+            // Returning null means the user is authenticated;
+            // otherwise the method returns a redirect to the login action.
+            return null;
         }
 
         public IActionResult Index()


### PR DESCRIPTION
## Summary
- update inline comment above `return null` to clarify that a `null` result means the user is authenticated and otherwise the method redirects

## Testing
- `dotnet test FutOrganizerWeb.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404e6711cc832f8f91db2a207f2f7a