### PR TITLE
Fix ID preservation in AtualizarSorteioAsync

### DIFF
--- a/FutOrganizerWeb.Infrastructure/Repositories/SorteioRepository.cs
+++ b/FutOrganizerWeb.Infrastructure/Repositories/SorteioRepository.cs
@@ -64,7 +64,7 @@ namespace FutOrganizerWeb.Infrastructure.Repositories
             _context.Entry(sorteioExistente).State = EntityState.Detached;
 
             // Adicionar novamente os novos dados
-            sorteio.Id = sorteio.Id; // manter o ID original
+            sorteio.Id = sorteioExistente.Id; // manter o ID original
             _context.Sorteios.Update(sorteio);
 
             await _context.SaveChangesAsync();


### PR DESCRIPTION
## Summary
- correct ID assignment when updating a sorteio

## Testing
- `dotnet build FutOrganizerWeb.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68404e5565a4832f8b622122c299b6c2